### PR TITLE
Refactor command structure for CLI

### DIFF
--- a/reshape-cli/Commands/Files/FileCommand.cs
+++ b/reshape-cli/Commands/Files/FileCommand.cs
@@ -11,12 +11,6 @@ namespace Reshape.Cli.Commands;
 /// </summary>
 internal sealed class FileCommand : AsynchronousCommandLineAction
 {
-    public static Command Command => new("file", "List, rename, and manage files")
-    {
-        Subcommands = { ListCommand.Command, RenameCommand.Command, PreviewCommand.Command },
-        Action = new FileCommand()
-    };
-
     public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         var noInteractive = parseResult.GetValue(GlobalOptions.NoInteractive);
@@ -37,17 +31,16 @@ internal sealed class FileCommand : AsynchronousCommandLineAction
                 "🔍 Preview Rename"
             ));
 
-        var command = commandString switch
+        AsynchronousCommandLineAction? command = commandString switch
         {
-            "📄 List Files" => ListCommand.Command,
-            "✏️ Rename Files" => RenameCommand.Command,
-            "🔍 Preview Rename" => PreviewCommand.Command,
+            "📄 List Files" => new ListCommand(),
+            "✏️ Rename Files" => new RenameCommand(),
+            "🔍 Preview Rename" => new PreviewCommand(),
             _ => null
         };
 
         return command is null
             ? 0
-            : await command.Parse([.. parseResult.Tokens.Select(t => t.Value)])
-                .InvokeAsync(cancellationToken: cancellationToken);
+            : await command.InvokeAsync(parseResult, cancellationToken);
     }
 }

--- a/reshape-cli/Commands/Files/ListCommand.cs
+++ b/reshape-cli/Commands/Files/ListCommand.cs
@@ -10,12 +10,6 @@ namespace Reshape.Cli.Commands;
 /// </summary>
 internal sealed class ListCommand : AsynchronousCommandLineAction
 {
-    public static Command Command => new("list", "List files in a folder")
-    {
-        Options = { GlobalOptions.Path, GlobalOptions.Extension },
-        Action = new ListCommand()
-    };
-
     public override Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         var path = parseResult.GetRequiredValue(GlobalOptions.Path);

--- a/reshape-cli/Commands/Files/PreviewCommand.cs
+++ b/reshape-cli/Commands/Files/PreviewCommand.cs
@@ -9,12 +9,6 @@ namespace Reshape.Cli.Commands;
 /// </summary>
 internal sealed class PreviewCommand : AsynchronousCommandLineAction
 {
-    public static Command Command => new("preview", "Preview rename operations")
-    {
-        Options = { GlobalOptions.Path, GlobalOptions.Pattern, GlobalOptions.Extension },
-        Action = new PreviewCommand()
-    };
-
     public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         await Task.Yield();

--- a/reshape-cli/Commands/Files/RenameCommand.cs
+++ b/reshape-cli/Commands/Files/RenameCommand.cs
@@ -9,12 +9,6 @@ namespace Reshape.Cli.Commands;
 /// </summary>
 internal sealed class RenameCommand : AsynchronousCommandLineAction
 {
-    public static Command Command => new("rename", "Execute rename operations")
-    {
-        Options = { GlobalOptions.Path, GlobalOptions.Pattern, GlobalOptions.Extension },
-        Action = new RenameCommand()
-    };
-
     public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         await Task.Yield();

--- a/reshape-cli/Commands/Patterns/PatternCommand.cs
+++ b/reshape-cli/Commands/Patterns/PatternCommand.cs
@@ -9,17 +9,6 @@ namespace Reshape.Cli.Commands.Patterns;
 /// </summary>
 internal sealed class PatternCommand : AsynchronousCommandLineAction
 {
-    public static Command Command => new("pattern", "Manage custom rename patterns")
-    {
-        Subcommands =
-        {
-            BuildAddCommand(),
-            BuildRemoveCommand(),
-            BuildListCommand()
-        },
-        Action = new PatternCommand()
-    };
-
     public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         await Task.Yield();
@@ -58,7 +47,7 @@ internal sealed class PatternCommand : AsynchronousCommandLineAction
         }
     }
 
-    private static Command BuildAddCommand()
+    public static Command BuildAddCommand()
     {
         var command = new Command("add", "Add a new custom pattern");
 
@@ -87,7 +76,7 @@ internal sealed class PatternCommand : AsynchronousCommandLineAction
         return command;
     }
 
-    private static Command BuildRemoveCommand()
+    public static Command BuildRemoveCommand()
     {
         var command = new Command("remove", "Remove a custom pattern");
 
@@ -109,7 +98,7 @@ internal sealed class PatternCommand : AsynchronousCommandLineAction
         return command;
     }
 
-    private static Command BuildListCommand()
+    public static Command BuildListCommand()
     {
         var command = new Command("list", "List all patterns (default and custom)");
         command.SetAction(_ => List());

--- a/reshape-cli/Commands/ReshapeCliCommand.cs
+++ b/reshape-cli/Commands/ReshapeCliCommand.cs
@@ -1,0 +1,54 @@
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Reshape.Cli.Commands;
+using Reshape.Cli.Commands.Patterns;
+using Spectre.Console;
+
+namespace Reshape.Cli.Commands;
+
+/// <summary>
+/// Handles the root command for the Reshape CLI.
+/// </summary>
+internal sealed class ReshapeCliCommand : AsynchronousCommandLineAction
+{
+    public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
+    {
+        var noInteractive = parseResult.GetValue(GlobalOptions.NoInteractive);
+
+        if (noInteractive)
+        {
+            AnsiConsole.MarkupLine("[red]Error: Please specify a subcommand in non-interactive mode[/]");
+            return 1;
+        }
+
+        AnsiConsole.Write(
+            new FigletText("Reshape CLI")
+                .LeftJustified()
+                .Color(Color.Cyan1));
+
+        AnsiConsole.MarkupLine("[dim]Batch rename files using metadata patterns[/]\n");
+
+        var commandString = AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("[cyan]What would you like to do?[/]")
+                .PageSize(10)
+                .AddChoices(
+                    "🌐 Run - Start Web UI",
+                     "📁 File - Manage Files",
+                    "🎨 Pattern - Manage Patterns"
+                ));
+
+        AsynchronousCommandLineAction? command = commandString switch
+        {
+            "🌐 Run - Start Web UI" => new RunCommand(),
+            "📁 File - Manage Files" => new FileCommand(),
+            "🎨 Pattern - Manage Patterns" => new PatternCommand(),
+            _ => null
+        };
+
+        return command is null
+            ? 0
+            : await command.InvokeAsync(parseResult, cancellationToken);
+    }
+}

--- a/reshape-cli/Commands/RunCommand.cs
+++ b/reshape-cli/Commands/RunCommand.cs
@@ -9,11 +9,6 @@ namespace Reshape.Cli.Commands;
 /// </summary>
 internal sealed class RunCommand : AsynchronousCommandLineAction
 {
-    public static Command Command => new("run", "Starts the Reshape web UI")
-    {
-        Action = new RunCommand()
-    };
-
     public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
     {
         var builder = WebApplication.CreateBuilder();


### PR DESCRIPTION
Refactor the command structure by removing static properties and implementing direct instantiation for file, list, rename, and preview commands. Introduce `ReshapeCliCommand` for improved interactive CLI handling. This change enhances command management and usability.

